### PR TITLE
[FIX] 콘텐츠 조회 알림 필터링 시 알림 예정만 가져오도록 수정

### DIFF
--- a/functions/db/categoryContent.js
+++ b/functions/db/categoryContent.js
@@ -30,8 +30,8 @@ const getCategoryContentByFilterAndNotified = async (client, userId, categoryId,
         SELECT c2.id, c2.title, c2.image, c2.description, c2.url, c2.is_seen, c2.is_notified, c2.notification_time, c2.created_at, c2.seen_at
         FROM category c
         JOIN category_content cc on c.id = cc.category_id
-        JOIN content c2 on cc.content_id = c2.id
-        WHERE c.id = $2 AND c2.user_id = $1 AND c2.is_deleted = FALSE AND c2.is_notified = ${option}
+        JOIN content c2 on cc.content_id = c2.id 
+        WHERE c.id = $2 AND c2.user_id = $1 AND c2.is_deleted = FALSE AND c2.is_notified = ${option} AND c2.notification_time > NOW()
         ORDER BY ${filter} DESC
         `,
         [userId, categoryId]

--- a/functions/db/content.js
+++ b/functions/db/content.js
@@ -80,7 +80,7 @@ const getContentsByFilterAndNotified = async (client, userId, option, filter) =>
         `
         SELECT c.id, c.title, c.image, c.description, c.url, c.is_seen, c.is_notified, c.notification_time, c.created_at, c.seen_at
         FROM content c
-        WHERE c.user_id = $1 AND c.is_deleted = FALSE AND c.is_notified = ${option}
+        WHERE c.user_id = $1 AND c.is_deleted = FALSE AND c.is_notified = ${option} AND c.notification_time > NOW()
         ORDER BY ${filter} DESC
         `,
         [userId]


### PR DESCRIPTION
 jobchae 에 합치면 알림 삭제랑 섞이니까 feature branch 에서 바로 pr 날립니다
- closes #239 

혜인이가 말한 거 수정했어요 ~ 
콘텐츠 조회 시 알림 필터 걸면 알림 예정인 콘텐츠만 나오도록 DB where 절 로직 추가했습니다.