### PR TITLE
[FEAT] 기존 유저 로그인 시 fcm 토큰 업데이트

### DIFF
--- a/functions/api/routes/auth/signinPOST.js
+++ b/functions/api/routes/auth/signinPOST.js
@@ -7,6 +7,7 @@ const { userDB } = require("../../../db");
 const functions = require("firebase-functions");
 const slackAPI = require("../../../middlewares/slackAPI");
 const jwtHandlers = require("../../../lib/jwtHandlers");
+const { modifyFcmToken } = require('../../../lib/pushServerHandlers');
 
 /**
  *  @route POST /auth/signin
@@ -51,6 +52,13 @@ module.exports = async (req, res) => {
         const accessToken = jwtHandlers.sign({ id: kakaoUser.id, idFirebase: kakaoUser.idFirebase });
         const refreshToken = jwtHandlers.signRefresh();
         const nickname = kakaoUser.nickname;
+
+        const response = await modifyFcmToken(kakaoUser.mongoUserId, fcmToken);
+
+        if (response.status != 204) {
+          return res.status(response.statusCode).send(util.fail(response.statusCode, responseMessage.PUSH_SERVER_ERROR));
+        }
+
         return res.status(statusCode.OK).send(util.success(statusCode.OK, responseMessage.SIGNIN_SUCCESS, 
           { firebaseAuthToken, accessToken, refreshToken, nickname }));
       };
@@ -70,6 +78,13 @@ module.exports = async (req, res) => {
         const refreshToken = jwtHandlers.signRefresh();
         const nickname = appleUser.nickname;
         const firebaseAuthToken = "";
+
+        const response = await modifyFcmToken(appleUser.mongoUserId, fcmToken);
+
+        if (response.status != 204) {
+          return res.status(response.statusCode).send(util.fail(response.statusCode, responseMessage.PUSH_SERVER_ERROR));
+        }
+
         return res.status(statusCode.OK).send(util.success(statusCode.OK, responseMessage.SIGNIN_SUCCESS, 
           { firebaseAuthToken, accessToken, refreshToken, nickname }));
       };


### PR DESCRIPTION
- closes #236 

회원 가입 시에만 푸시 토큰 처리를 해줬어서 
기존 유저 로그인 시 바뀐 푸시 토큰 업데이트 로직을 추가했습니다.
아직 알림 삭제 merge 를 못해서 develop 으로 바로 pr 날립니다~!