### PR TITLE
[FIX] Github Actions 설정 파일에서 배포할 Firebase Project 명시적으로 지정

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -65,6 +65,7 @@ jobs:
       - name: Deploy to Firebase
         run: |
           cd functions
-          npm run deploy
+          firebase use development
+          npm run dev
         env: 
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -65,6 +65,7 @@ jobs:
       - name: Deploy to Firebase
         run: |
           cd functions
+          firebase use production
           npm run deploy
         env: 
           FIREBASE_TOKEN: ${{ secrets.PROD_FIREBASE_TOKEN }}


### PR DESCRIPTION
close #283 

- 배포 대상 Firebase Project yml 파일에서 명시적으로 지정