### PR TITLE
[FIX] 유저 탈퇴시 푸시서버 유저 삭제 연동

### DIFF
--- a/functions/api/routes/auth/userDELETE.js
+++ b/functions/api/routes/auth/userDELETE.js
@@ -7,6 +7,7 @@ const db = require('../../../db/db');
 const { userDB } = require("../../../db");
 const { getAuth } = require('firebase-admin/auth');
 const { nanoid } = require("nanoid");
+const { deletePushUser } = require('../../../lib/pushServerHandlers');
 
 /**
  *  @route DELETE /auth/user
@@ -22,13 +23,17 @@ module.exports = async (req, res) => {
   
   try {
     client = await db.connect(req);
+
     deleteUser = await userDB.getUser(client, userId); // DB에서 해당 유저 정보 받아 옴    
   } catch (error) {
     functions.logger.error(`[ERROR] [${req.method.toUpperCase()}] ${req.originalUrl}`, `[CONTENT] ${error}`);
     console.log(error);
+    
     const slackMessage = `[ERROR] [${req.method.toUpperCase()}] ${req.originalUrl} ${req.user ? `uid:${req.user.userId}` : 'req.user 없음'} ${JSON.stringify(error)}`;
     slackAPI.sendMessageToSlack(slackMessage, slackAPI.WEB_HOOK_ERROR_MONITORING);
+    
     client.release();
+    
     return res.status(statusCode.INTERNAL_SERVER_ERROR).send(util.fail(statusCode.INTERNAL_SERVER_ERROR, responseMessage.INTERNAL_SERVER_ERROR)); // DB 관련 에러 : 500 INTERNAL SERVER ERROR
   } 
 
@@ -37,9 +42,12 @@ module.exports = async (req, res) => {
   } catch (error) {
     functions.logger.error(`[ERROR] [${req.method.toUpperCase()}] ${req.originalUrl}`, `[CONTENT] ${error}`);
     console.log(error);
+    
     const slackMessage = `[ERROR] [${req.method.toUpperCase()}] ${req.originalUrl} ${req.user ? `uid:${req.user.userId}` : 'req.user 없음'} ${JSON.stringify(error)}`;
     slackAPI.sendMessageToSlack(slackMessage, slackAPI.WEB_HOOK_ERROR_MONITORING);
+    
     client.release();
+    
     if (error.errorInfo.code === 'auth/user-not-found') {
       return res.status(statusCode.NOT_FOUND).send(util.fail(statusCode.NOT_FOUND, responseMessage.NO_USER)); // Firebase Auth에 해당 유저 존재하지 않을 경우 : 404 NOT FOUND
     } else {
@@ -50,6 +58,12 @@ module.exports = async (req, res) => {
   try {
     const randomString = `:${nanoid(10)}`;
     await userDB.deleteUser(client, userId, randomString); // DB에서 해당 유저 삭제
+
+    const response = await deletePushUser(deleteUser.mongoUserId);
+    if (response.status != 204) {
+      return res.status(response.statusCode).send(util.fail(response.statusCode, response.statusText));
+    }
+
     res.status(statusCode.OK).send(util.success(statusCode.OK, responseMessage.DELETE_USER));
   } catch (error) {
     functions.logger.error(`[ERROR] [${req.method.toUpperCase()}] ${req.originalUrl}`, `[CONTENT] ${error}`);

--- a/functions/lib/pushServerHandlers.js
+++ b/functions/lib/pushServerHandlers.js
@@ -58,4 +58,12 @@ const modifyContentTitle = async (contentId, ogTitle) => {
     return response;
 }
 
-module.exports = { createPushServerUser, createNotification, modifyNotificationTime, modifyFcmToken, deleteNotification, modifyContentTitle }
+const deletePushUser = async (mongoUserId) => {
+    const url = `${baseURL}user/${mongoUserId}`;
+
+    const response = await axios.delete(url);
+
+    return response;
+} 
+
+module.exports = { createPushServerUser, createNotification, modifyNotificationTime, modifyFcmToken, deleteNotification, modifyContentTitle, deletePushUser }


### PR DESCRIPTION
- close #303 

유저 탈퇴 후 재가입시 fcmToken 중복 문제가 발생하지 않도록
유저 탈퇴 시 푸시서버 유저 삭제 api 를 연동했습니다.