### PR TITLE
[FIX] apple 로그인 시 토큰 발급 및 탈퇴 시 revoke

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -47,7 +47,13 @@ jobs:
           echo "JWT_ALGORITHM=${{ secrets.JWT_ALGORITHM }}" >> .env.dev
           echo "JWT_ACCESS_EXPIRE=${{ secrets.JWT_ACCESS_EXPIRE }}" >> .env.dev
           echo "JWT_REFRESH_EXPIRE=${{ secrets.JWT_REFRESH_EXPIRE }} " >> .env.dev
- 
+      
+      - name: create .p8 file
+        run: |
+          cd functions
+          touch ${{ secrets.APPLE_PRIVATE_KEY_FILE }}
+          echo ${{ secrets.APPLE_PRIVATE_KEY }} >> ${{ secrets.APPLE_PRIVATE_KEY_FILE }}
+
       - name: create-json
         id: create-dev-json
         uses: jsdaniell/create-json@1.1.2

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -47,6 +47,12 @@ jobs:
           echo "JWT_ALGORITHM=${{ secrets.JWT_ALGORITHM }}" >> .env.prod
           echo "JWT_ACCESS_EXPIRE=${{ secrets.JWT_ACCESS_EXPIRE }}" >> .env.prod
           echo "JWT_REFRESH_EXPIRE=${{ secrets.JWT_REFRESH_EXPIRE }} " >> .env.prod
+            
+      - name: create .p8 file
+        run: |
+          cd functions
+          touch ${{ secrets.APPLE_PRIVATE_KEY_FILE }}
+          echo ${{ secrets.APPLE_PRIVATE_KEY }} >> ${{ secrets.APPLE_PRIVATE_KEY_FILE }}
  
       - name: create-json
         id: create-json

--- a/functions/.gitignore
+++ b/functions/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 ./package-lock.json
+*.p8

--- a/functions/api/routes/auth/signupPOST.js
+++ b/functions/api/routes/auth/signupPOST.js
@@ -8,6 +8,7 @@ const functions = require("firebase-functions");
 const slackAPI = require("../../../middlewares/slackAPI");
 const jwtHandlers = require("../../../lib/jwtHandlers");
 const { createPushServerUser } = require("../../../lib/pushServerHandlers");
+const { getAppleRefreshToken } = require("../../../lib/appleAuth");
 
 /**
  *  @route POST /auth/signup
@@ -16,7 +17,7 @@ const { createPushServerUser } = require("../../../lib/pushServerHandlers");
  */
 
 module.exports = async (req, res) => {
-  const { fcmToken, kakaoAccessToken, firebaseUID, nickname, email, age, gender, isOption } = req.body;
+  const { fcmToken, kakaoAccessToken, firebaseUID, appleCode, nickname, email, age, gender, isOption } = req.body;
 
   if (!fcmToken || (!firebaseUID && !kakaoAccessToken)) {
     // fcmToken이 없거나 firebaseUID와 kakaoAccessToken이 모두 없을 때 : 에러
@@ -27,6 +28,11 @@ module.exports = async (req, res) => {
     // firebaseUID와 kakaoAccessToken이 모두 있을 때 : 에러
     return res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, responseMessage.OUT_OF_VALUE));
   };
+
+  if (firebaseUID && !appleCode) {
+    // firebaseUID 는 있으나 appleCode 가 없을 때 : 에러
+    return res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, responseMessage.NULL_VALUE));
+  }
 
   let client;
 
@@ -50,6 +56,11 @@ module.exports = async (req, res) => {
       const appleUser = await userDB.addUser(client, firebaseUID, nickname, email, age, gender, isOption, mongoId, refreshToken);
       const accessToken = jwtHandlers.sign({ id: appleUser.id, idFirebase: appleUser.idFirebase });
       const firebaseAuthToken = "";
+
+      // apple refresh token 발급
+      const appleRefreshToken = await getAppleRefreshToken(appleCode);
+      await userDB.updateAppleRefreshToken(client, appleUser.id, appleRefreshToken);
+
       return res.status(statusCode.CREATED).send(util.success(statusCode.CREATED, responseMessage.SIGNUP_SUCCESS, { firebaseAuthToken, accessToken, refreshToken, nickname }));
     }
   } catch (error) {

--- a/functions/api/routes/auth/userDELETE.js
+++ b/functions/api/routes/auth/userDELETE.js
@@ -8,6 +8,7 @@ const { userDB } = require("../../../db");
 const { getAuth } = require('firebase-admin/auth');
 const { nanoid } = require("nanoid");
 const { deletePushUser } = require('../../../lib/pushServerHandlers');
+const { revokeAppleToken } = require('../../../lib/appleAuth');
 
 /**
  *  @route DELETE /auth/user
@@ -25,6 +26,10 @@ module.exports = async (req, res) => {
     client = await db.connect(req);
 
     deleteUser = await userDB.getUser(client, userId); // DB에서 해당 유저 정보 받아 옴    
+
+    if (deleteUser.appleRefreshToken) {
+      await revokeAppleToken(deleteUser.appleRefreshToken); // 애플 유저라면 애플 계정 연동 해지
+    }
   } catch (error) {
     functions.logger.error(`[ERROR] [${req.method.toUpperCase()}] ${req.originalUrl}`, `[CONTENT] ${error}`);
     console.log(error);

--- a/functions/db/user.js
+++ b/functions/db/user.js
@@ -61,6 +61,17 @@ const updateRefreshToken = async (client, userId, newRefreshToken) => {
     );
 };
 
+const updateAppleRefreshToken = async (client, userId, appleRefreshToken) => {
+    const { rows } = await client.query(
+        `
+        UPDATE "user"
+        SET apple_refresh_token = $2
+        WHERE id = $1
+        `,
+        [userId, appleRefreshToken]
+    );
+};
+
 const updateNickname = async (client, userId, newNickname) => {
     const { rows } = await client.query(
         `
@@ -83,4 +94,4 @@ const deleteUser = async (client, userId, randomString) => {
     )
 }
 
-module.exports = { getUser, getUserByFirebaseId, addUser, updateUserByLogin, updateRefreshToken, updateNickname, deleteUser };
+module.exports = { getUser, getUserByFirebaseId, addUser, updateUserByLogin, updateRefreshToken, updateAppleRefreshToken, updateNickname, deleteUser };

--- a/functions/lib/appleAuth.js
+++ b/functions/lib/appleAuth.js
@@ -1,0 +1,81 @@
+const axios = require('axios');
+const jwt = require('jsonwebtoken'); 
+const functions = require("firebase-functions");
+const slackAPI = require("../middlewares/slackAPI");
+const fs = require('fs');
+const { resolve } = require('path');
+const qs = require('qs');
+
+const appleBaseURL = "https://appleid.apple.com";
+
+const privateKey = fs.readFileSync(resolve(__dirname, `../${process.env.APPLE_PRIVATE_KEY_FILE}`), 'utf8');
+
+const header = {
+    kid: process.env.APPLE_KEY_ID,
+};
+
+const payload = {
+    iss: process.env.APPLE_TEAM_ID,
+    iat: Math.floor(Date.now() / 1000),
+    exp: Math.floor(Date.now() / 1000) + 15777000,
+    aud: appleBaseURL,
+    sub: process.env.APPLE_CLIENT_ID,
+};
+
+/**
+ *  @desc apple 서버에 refresh token 요청
+ *  @param {String} appleCode
+ */
+const getAppleRefreshToken = async (appleCode) => {
+    const clientSecret = jwt.sign(payload, privateKey, {
+        algorithm: 'ES256',
+        header
+    });
+    
+    const data = {
+        'client_id': process.env.APPLE_CLIENT_ID,
+        'client_secret': clientSecret,
+        'code': appleCode,
+        'grant_type': 'authorization_code'
+    };
+
+    try {
+        const response = await axios.post(`${appleBaseURL}/auth/token`, qs.stringify(data));
+        
+        return response.data.refresh_token;
+    } catch (error) {
+        functions.logger.error(`[ERROR] Get Apple Access Token` , `[CONTENT] ${error}`);
+        const slackMessage = `[ERROR] Get Apple Access Token ${JSON.stringify(error)}`;
+        slackAPI.sendMessageToSlack(slackMessage, slackAPI.WEB_HOOK_ERROR_MONITORING);
+        throw error;
+    } 
+}
+
+/**
+ * @desc apple 서버에 소셜 로그인 연결 해지 요청
+ * @param {String} appleRefreshToken
+ */
+const revokeAppleToken = async (appleRefreshToken) => {
+    const clientSecret = jwt.sign(payload, privateKey, {
+        algorithm: 'ES256',
+        header
+    });
+
+    const data = {
+        'client_id': process.env.APPLE_CLIENT_ID,
+        'client_secret': clientSecret,
+        'token': appleRefreshToken,
+        'token_type_hint': 'refresh_token',
+    };
+
+    try {
+        await axios.post(`${appleBaseURL}/auth/revoke`, qs.stringify(data));
+    } catch (error) {
+        functions.logger.error(`[ERROR] Get Apple Access Token`, `[CONTENT] ${error}`);
+        const slackMessage = `[ERROR] Get Apple Access Token ${JSON.stringify(error)}`;
+        slackAPI.sendMessageToSlack(slackMessage, slackAPI.WEB_HOOK_ERROR_MONITORING);
+        throw error;
+    }
+}
+
+module.exports = { getAppleRefreshToken, revokeAppleToken }


### PR DESCRIPTION
- close #307 

### 수정 내용
애플 로그인 후 탈퇴 시 토큰을 애플 서버에 revoke 하지 않아 재가입시 유저 정보를 받아오지 못하는 버그를 수정했습니다.

### 변경 사항
- 애플 서버와의 외부 api 요청을 하는 `appleAuth.js` 작성 (generate token, revoke token)
- 회원가입/로그인 시 apple `refresh_token` 발급 후 DB 필드 업데이트
- 유저 탈퇴 시 DB에 있던 `apple_refresh_token` 으로 새 `access_token` 발급 후 revoke 요청
- DB user table `apple_refresh_token` 필드 추가함 (현재 dev db 만)

### 추가 된 env 및 파일
- `AuthKey-xxxxx.p8` 애플 고유 private key file -> github actions 에서 어떻게 만들어낼지 고민이 필요합니다.
- APPLE_CLIENTID, APPLE_KEY_ID, APPLE_TEAM_ID

탈퇴 후 apple revoke 완료시 메일 화면
<img width="948" alt="image" src="https://user-images.githubusercontent.com/20807197/214642093-b26a99b6-fddf-4928-9696-01cc386e9db2.png">