### PR TITLE
[FIX] 콘텐츠, 카테고리 중복 삭제 방지 로직 추가

### DIFF
--- a/functions/api/routes/category/categoryDELETE.js
+++ b/functions/api/routes/category/categoryDELETE.js
@@ -17,6 +17,15 @@ module.exports = asyncWrapper(async (req, res) => {
 
     const dbConnection = await db.connect(req);
     req.dbConnection = dbConnection;
+
+    const category = await categoryDB.getCategory(dbConnection, categoryId);
+    if (!category) {
+        return res.status(statusCode.NOT_FOUND).send(util.fail(statusCode.NOT_FOUND, responseMessage.NO_CATEGORY));
+    }
+    if (category.userId !== userId) {
+    return res.status(statusCode.FORBIDDEN).send(util.fail(statusCode.FORBIDDEN, responseMessage.FORBIDDEN));
+    }
+
     await Promise.all([
         categoryDB.deleteCategory(dbConnection, categoryId, userId), // 해당 카테고리 soft delete
         contentDB.updateContentIsDeleted(dbConnection, categoryId, userId), // 카테고리 개수가 1개 (해당 카테고리뿐)인 콘텐츠 soft delete

--- a/functions/api/routes/category/categoryDELETE.js
+++ b/functions/api/routes/category/categoryDELETE.js
@@ -23,7 +23,7 @@ module.exports = asyncWrapper(async (req, res) => {
         return res.status(statusCode.NOT_FOUND).send(util.fail(statusCode.NOT_FOUND, responseMessage.NO_CATEGORY));
     }
     if (category.userId !== userId) {
-    return res.status(statusCode.FORBIDDEN).send(util.fail(statusCode.FORBIDDEN, responseMessage.FORBIDDEN));
+        return res.status(statusCode.FORBIDDEN).send(util.fail(statusCode.FORBIDDEN, responseMessage.FORBIDDEN));
     }
 
     await Promise.all([

--- a/functions/api/routes/content/contentDELETE.js
+++ b/functions/api/routes/content/contentDELETE.js
@@ -35,15 +35,14 @@ module.exports = asyncWrapper(async (req, res) => {
   dayjs.tz.setDefault('Asia/Seoul');
 
   const content = await contentDB.getContentById(dbConnection, contentId);
+  if (!content) {
+    return res.status(statusCode.NOT_FOUND).send(util.fail(statusCode.NOT_FOUND, responseMessage.NO_CONTENT));
+  }
   if (content.userId !== userId) {
     return res.status(statusCode.FORBIDDEN).send(util.fail(statusCode.FORBIDDEN, responseMessage.FORBIDDEN));
   }
 
-  const deletedContent = await contentDB.deleteContent(dbConnection, contentId, userId);
-  if (!deletedContent) {
-    // 대상 콘텐츠가 없는 경우, 콘텐츠 삭제 실패
-    return res.status(statusCode.NOT_FOUND).send(util.fail(statusCode.NOT_FOUND, responseMessage.NO_CONTENT));
-  }
+  await contentDB.deleteContent(dbConnection, contentId, userId);
 
   if (content.isNotified && content.notificationTime > dayjs().tz().$d) {
     // 알림 예정 일 때 푸시서버에서도 삭제


### PR DESCRIPTION
- #318 
- 콘텐츠, 카테고리 삭제 버튼 중복 터치 시 500 에러를 방지하기 위해 필요한 로직 추가했습니다.