### PR TITLE
[FEAT] 로그인 / 회원가입 성공 시 user id 반환

### DIFF
--- a/functions/api/routes/auth/signinPOST.js
+++ b/functions/api/routes/auth/signinPOST.js
@@ -58,7 +58,7 @@ module.exports = asyncWrapper(async (req, res) => {
       await userDB.updateRefreshToken(dbConnection, kakaoUser.id, refreshToken);
 
       return res.status(statusCode.OK).send(util.success(statusCode.OK, responseMessage.SIGNIN_SUCCESS, 
-        { firebaseAuthToken, accessToken, refreshToken, nickname }));
+        { firebaseAuthToken, accessToken, refreshToken, id: kakaoUser.id, nickname }));
     };
   } 
   else {
@@ -90,7 +90,7 @@ module.exports = asyncWrapper(async (req, res) => {
       await userDB.updateRefreshToken(dbConnection, appleUser.id, refreshToken);
       
       return res.status(statusCode.OK).send(util.success(statusCode.OK, responseMessage.SIGNIN_SUCCESS, 
-        { firebaseAuthToken, accessToken, refreshToken, nickname }));
+        { firebaseAuthToken, accessToken, refreshToken, id: appleUser.id, nickname }));
     };
   }
 });

--- a/functions/api/routes/auth/signupPOST.js
+++ b/functions/api/routes/auth/signupPOST.js
@@ -38,7 +38,7 @@ module.exports = asyncWrapper(async (req, res) => {
     const refreshToken = jwtHandlers.signRefresh();
     const kakaoUser = await userDB.addUser(dbConnection, firebaseUserId, nickname, email, age, gender, isOption, mongoId, refreshToken);
     const accessToken = jwtHandlers.sign({ id: kakaoUser.id, idFirebase: kakaoUser.idFirebase });
-    return res.status(statusCode.CREATED).send(util.success(statusCode.CREATED, responseMessage.SIGNUP_SUCCESS, { firebaseAuthToken, accessToken, refreshToken, nickname }));
+    return res.status(statusCode.CREATED).send(util.success(statusCode.CREATED, responseMessage.SIGNUP_SUCCESS, { firebaseAuthToken, accessToken, refreshToken, id: kakaoUser.id, nickname }));
   } 
   else {
     // kakaoAccessToken이 없을 때 (!kakaoAccessToken) : 애플 소셜 로그인
@@ -51,6 +51,6 @@ module.exports = asyncWrapper(async (req, res) => {
     const appleRefreshToken = await getAppleRefreshToken(appleCode);
     await userDB.updateAppleRefreshToken(dbConnection, appleUser.id, appleRefreshToken);
 
-    return res.status(statusCode.CREATED).send(util.success(statusCode.CREATED, responseMessage.SIGNUP_SUCCESS, { firebaseAuthToken, accessToken, refreshToken, nickname }));
+    return res.status(statusCode.CREATED).send(util.success(statusCode.CREATED, responseMessage.SIGNUP_SUCCESS, { firebaseAuthToken, accessToken, refreshToken, id: appleUser.id, nickname }));
   }
 });


### PR DESCRIPTION
close #320 
- 지난 번 클라 회의 때 논의한 대로, 로그인 / 회원가입 성공 시 `userId`를 반환하는 로직을 추가했습니다.