### PR TITLE
[FEAT] swagger setup 

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -53,6 +53,7 @@ jobs:
           echo "JWT_REFRESH_EXPIRE=${{ secrets.JWT_REFRESH_EXPIRE }} " >> .env.dev
           echo "SENTRY_DSN=${{ secrets.DEV_SENTRY_DSN }} " >> .env.dev
           echo "SENTRY_TRACES_SAMPLE_RATE=${{ secrets.DEV_SENTRY_TRACES_SAMPLE_RATE }} " >> .env.dev
+          echo "DEV_HOST=${{ secrets.DEV_HOST }} " >> .env.dev
       
       - name: create .p8 file
         run: |
@@ -82,6 +83,11 @@ jobs:
           npm install
           npm install -g firebase-tools
           npm install --save-dev cross-env
+      
+      - name: Create swagger output file
+        run: |
+          cd functions
+          npm run swagger
       
       - name: Deploy to Firebase
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -76,4 +76,6 @@ deployMessageToSlack.sh
 havit-server-key.cer
 
 AuthKey_*
+
+# Swagger
 swagger-output.json

--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ deployMessageToSlack.sh
 
 # AWS cert
 havit-server-key.cer
+
+AuthKey_*
+swagger-output.json

--- a/functions/api/index.js
+++ b/functions/api/index.js
@@ -7,6 +7,8 @@ const hpp = require("hpp");
 const helmet = require("helmet");
 const Sentry = require('@sentry/node');
 const errorHandler = require('../middlewares/errorHandler');
+const swaggerUi = require("swagger-ui-express");
+const swaggerFile = require("../constants/swagger/swagger-output.json");
 
 // initializing
 const app = express();
@@ -41,6 +43,11 @@ if (process.env.NODE_ENV === "production") {
 app.use(express.json());
 app.use(express.urlencoded({extended: true}));
 app.use(cookieParser());
+
+if (process.env.NODE_ENV === "development") {
+    app.use("/swagger", swaggerUi.serve);
+    app.get("/swagger", swaggerUi.setup(swaggerFile));
+}
 
 // 라우팅: routes 폴더로 정리
 app.use("/", require("./routes"));

--- a/functions/api/routes/index.js
+++ b/functions/api/routes/index.js
@@ -1,12 +1,118 @@
 const express = require('express');
 const router = express.Router();
 
-router.use('/content', require('./content'));
-router.use('/category', require('./category'));
-router.use('/recommendation', require('./recommendation'));
-router.use('/user', require('./user'));
-router.use('/auth', require('./auth'));
-router.use('/notice', require('./notice'));
-router.use('/health', require('./health'));
+router.use(
+    '/content', require('./content') 
+    /** 
+     * #swagger.tags = ['content'] 
+     * #swagger.responses[500] = {
+           description: "Internal Server Error",
+           content: {
+               "application/json": {
+                   schema:{
+                       $ref: "#/components/schemas/internalServerErrorSchema"
+                   }
+               }           
+           }
+       }   
+   */ 
+);
+router.use(
+    '/category', require('./category')
+    /** 
+     * #swagger.tags = ['category'] 
+     * #swagger.responses[500] = {
+           description: "Internal Server Error",
+           content: {
+               "application/json": {
+                   schema:{
+                       $ref: "#/components/schemas/internalServerErrorSchema"
+                   }
+               }           
+           }
+       }   
+   */
+);
+router.use(
+    '/recommendation', require('./recommendation')
+    /** 
+     * #swagger.tags = ['recommendation']
+     * #swagger.responses[500] = {
+           description: "Internal Server Error",
+           content: {
+               "application/json": {
+                   schema:{
+                       $ref: "#/components/schemas/internalServerErrorSchema"
+                   }
+               }           
+           }
+       }   
+   */
+);
+router.use(
+    '/user', require('./user')
+    /** 
+     * #swagger.tags = ['user'] 
+     * #swagger.responses[500] = {
+           description: "Internal Server Error",
+           content: {
+               "application/json": {
+                   schema:{
+                       $ref: "#/components/schemas/internalServerErrorSchema"
+                   }
+               }           
+           }
+       }   
+   */
+);
+router.use(
+    '/auth', require('./auth')
+    /** 
+     * #swagger.tags = ['auth'] 
+     * #swagger.responses[500] = {
+           description: "Internal Server Error",
+           content: {
+               "application/json": {
+                   schema:{
+                       $ref: "#/components/schemas/internalServerErrorSchema"
+                   }
+               }           
+           }
+       }   
+   */
+);
+router.use(
+    '/notice', require('./notice')
+    /** 
+     * #swagger.tags = ['notice'] 
+     * #swagger.responses[500] = {
+           description: "Internal Server Error",
+           content: {
+               "application/json": {
+                   schema:{
+                       $ref: "#/components/schemas/internalServerErrorSchema"
+                   }
+               }           
+           }
+       }   
+   */
+    
+);
+router.use(
+    '/health', require('./health')
+    /** 
+     * #swagger.tags = ['health'] 
+     * #swagger.responses[500] = {
+           description: "Internal Server Error",
+           content: {
+               "application/json": {
+                   schema:{
+                       $ref: "#/components/schemas/internalServerErrorSchema"
+                   }
+               }           
+           }
+       }   
+   */
+);
 
 module.exports = router;

--- a/functions/api/routes/notice/index.js
+++ b/functions/api/routes/notice/index.js
@@ -1,6 +1,21 @@
 const express = require('express');
 const router = express.Router();
 
-router.get('/', require('./noticeGET'));
+router.get(
+    '/', require('./noticeGET')
+    /**
+     * #swagger.summary = "공지사항 전체 조회"
+     * #swagger.responses[200] = {
+           description: "공지사항 조회 성공",
+           content: {
+               "application/json": {
+                   schema:{
+                       $ref: "#/components/schemas/responseNoticeSchema"
+                   }
+               }           
+           }
+       }   
+   */
+);
 
 module.exports = router;

--- a/functions/config/swagger.js
+++ b/functions/config/swagger.js
@@ -1,0 +1,42 @@
+const swaggerAutogen = require('swagger-autogen')({ openapi: '3.0.0' });
+const { commonErrorSchema, noticeSchema } = require('../constants/swagger/schemas');
+const dotenv = require('dotenv');
+dotenv.config({ path: '.env.dev' });
+
+const options = {
+    info: {
+        title: 'HAVIT API Docs',
+        description: 'HAVIT APP server API 문서입니다',
+    },
+    host: "http://localhost:5001",
+    servers: [
+        {
+            url: 'http://localhost:5001/havit-production/asia-northeast3/api',
+            description: '로컬 개발환경 host',
+        },
+        {
+            url: process.env.DEV_HOST,
+            description: '개발환경 host',
+        },
+    ],
+    schemes: ['http'],
+    securityDefinitions: {
+        bearerAuth: {
+            type: 'http',
+            name: 'x-auth-token',
+            in: 'header',
+            bearerFormat: 'JWT',
+        },
+    },
+    components: {
+        schemas: {
+            ...commonErrorSchema,
+            ...noticeSchema,
+        }
+    }
+};
+
+const outputFile = '../constants/swagger/swagger-output.json';
+const endpointsFiles = ['../api/index.js'];
+
+swaggerAutogen(outputFile, endpointsFiles, options);

--- a/functions/constants/swagger/schemas/commonErrorSchema.js
+++ b/functions/constants/swagger/schemas/commonErrorSchema.js
@@ -1,0 +1,9 @@
+const internalServerErrorSchema = {
+    $status: 500,
+    $success: false,
+    $message: "서버 내부 오류",
+};
+
+module.exports = {
+    internalServerErrorSchema
+}

--- a/functions/constants/swagger/schemas/index.js
+++ b/functions/constants/swagger/schemas/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+    commonErrorSchema: require('./commonErrorSchema'),
+    noticeSchema: require('./noticeSchema'),
+}

--- a/functions/constants/swagger/schemas/noticeSchema.js
+++ b/functions/constants/swagger/schemas/noticeSchema.js
@@ -1,0 +1,16 @@
+const responseNoticeSchema = {
+    $status: 200,
+    $success: true,
+    $message: "공지사항 조회 성공",
+    $data: [
+        {
+            $title: "notice title",
+            $url: "notice url",
+            $createdAt: "2022-09-15"
+        }
+    ]
+};
+
+module.exports = {
+    responseNoticeSchema
+}

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -34,7 +34,9 @@
         "eslint-config-google": "^0.14.0",
         "firebase-functions-test": "^0.2.0",
         "mocha": "^9.2.1",
-        "supertest": "^6.2.2"
+        "supertest": "^6.2.2",
+        "swagger-autogen": "^2.23.7",
+        "swagger-ui-express": "^5.0.0"
       },
       "engines": {
         "node": "16"
@@ -1602,6 +1604,15 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/defer-to-connect": {
       "version": "2.0.1",
@@ -3172,6 +3183,18 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/jsonwebtoken": {
       "version": "8.5.1",
@@ -4798,6 +4821,39 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/swagger-autogen": {
+      "version": "2.23.7",
+      "resolved": "https://registry.npmjs.org/swagger-autogen/-/swagger-autogen-2.23.7.tgz",
+      "integrity": "sha512-vr7uRmuV0DCxWc0wokLJAwX3GwQFJ0jwN+AWk0hKxre2EZwusnkGSGdVFd82u7fQLgwSTnbWkxUL7HXuz5LTZQ==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^7.4.1",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.7",
+        "json5": "^2.2.3"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.11.8",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.11.8.tgz",
+      "integrity": "sha512-IfPtCPdf6opT5HXrzHO4kjL1eco0/8xJCtcs7ilhKuzatrpF2j9s+3QbOag6G3mVFKf+g+Ca5UG9DquVUs2obA==",
+      "dev": true
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.0.tgz",
+      "integrity": "sha512-tsU9tODVvhyfkNSvf03E6FAk+z+5cU3lXAzMy6Pv4av2Gt2xA0++fogwC4qo19XuFf6hdxevPuVCSKFuMHJhFA==",
+      "dev": true,
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/table": {
@@ -6518,6 +6574,12 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
     },
+    "deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true
+    },
     "defer-to-connect": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
@@ -7700,6 +7762,12 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true
     },
     "jsonwebtoken": {
       "version": "8.5.1",
@@ -8918,6 +8986,33 @@
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
         "has-flag": "^3.0.0"
+      }
+    },
+    "swagger-autogen": {
+      "version": "2.23.7",
+      "resolved": "https://registry.npmjs.org/swagger-autogen/-/swagger-autogen-2.23.7.tgz",
+      "integrity": "sha512-vr7uRmuV0DCxWc0wokLJAwX3GwQFJ0jwN+AWk0hKxre2EZwusnkGSGdVFd82u7fQLgwSTnbWkxUL7HXuz5LTZQ==",
+      "dev": true,
+      "requires": {
+        "acorn": "^7.4.1",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.7",
+        "json5": "^2.2.3"
+      }
+    },
+    "swagger-ui-dist": {
+      "version": "5.11.8",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.11.8.tgz",
+      "integrity": "sha512-IfPtCPdf6opT5HXrzHO4kjL1eco0/8xJCtcs7ilhKuzatrpF2j9s+3QbOag6G3mVFKf+g+Ca5UG9DquVUs2obA==",
+      "dev": true
+    },
+    "swagger-ui-express": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.0.tgz",
+      "integrity": "sha512-tsU9tODVvhyfkNSvf03E6FAk+z+5cU3lXAzMy6Pv4av2Gt2xA0++fogwC4qo19XuFf6hdxevPuVCSKFuMHJhFA==",
+      "dev": true,
+      "requires": {
+        "swagger-ui-dist": ">=5.0.0"
       }
     },
     "table": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -9,7 +9,8 @@
     "dev": "cross-env NODE_ENV=development firebase deploy --only functions,hosting",
     "deploy": "cross-env NODE_ENV=production firebase deploy --only functions,hosting",
     "logs": "firebase functions:log",
-    "test": "mocha"
+    "test": "mocha",
+    "swagger": "node config/swagger.js"
   },
   "engines": {
     "node": "16"
@@ -44,7 +45,9 @@
     "eslint-config-google": "^0.14.0",
     "firebase-functions-test": "^0.2.0",
     "mocha": "^9.2.1",
-    "supertest": "^6.2.2"
+    "supertest": "^6.2.2",
+    "swagger-autogen": "^2.23.7",
+    "swagger-ui-express": "^5.0.0"
   },
   "private": true
 }


### PR DESCRIPTION
- close #326 

### 작업 내용
- `swagger-autogen`, `swagger-ui-express` 사용해서 라우트별 swagger 자동 생성 세팅했습니다.
- route 에 따라 auth generate 되긴 하는데 세부적으로 tags, description, response 스키마는 직접 세팅해야합니다. 
- 예시로 notice 전체 조회에 샘플로 명세해봤습니다.
- `NODE_ENV=development` 일때만 `host_url/swagger/` 주소로 접근 가능합니다. production 일 경우 404 나도록 세팅했어요.
   - 주의) 꼭 swagger 뒤에 '/' 대시 끝에도 붙여줘야 접속되고 안그러면 리다이렉트 나요;;; 
   - swagger-output.json 같은 경우 host 주소 같은 정보가 들어있어 .gitignore 에 추가해놨습니다. 배포 시 `npm run swagger` 로 생성하도록 파이프라인에 해당 명령어 추가했어요.
<img width="1552" alt="image" src="https://github.com/TeamHavit/Havit-Server/assets/20807197/0cf89ebe-4ea3-4bb3-bd2c-e97c8dca586a">
<img width="1552" alt="image" src="https://github.com/TeamHavit/Havit-Server/assets/20807197/1144742c-8146-45a3-82b4-d4a88801169a">

### 참고 링크
- [swagger-autogen official docs](https://swagger-autogen.github.io/docs)