### PR TITLE
[FEAT] 커뮤니티 카테고리, 게시글 상세 조회 swagger 명세

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ AuthKey_*
 
 # Swagger
 swagger-output.json
+
+#VSCode
+.vscode

--- a/functions/api/index.js
+++ b/functions/api/index.js
@@ -14,14 +14,14 @@ const swaggerFile = require("../constants/swagger/swagger-output.json");
 const app = express();
 
 Sentry.init({
-  dsn: process.env.SENTRY_DSN,
-  environment: `${process.env.NODE_ENV}_app`,
-  integrations: [
-    new Sentry.Integrations.Http({ tracing: true }),
-    new Sentry.Integrations.Express({ app }),
-    ...Sentry.autoDiscoverNodePerformanceMonitoringIntegrations(),
-  ],
-  tracesSampleRate: process.env.SENTRY_TRACES_SAMPLE_RATE,
+    dsn: process.env.SENTRY_DSN,
+    environment: `${process.env.NODE_ENV}_app`,
+    integrations: [
+        new Sentry.Integrations.Http({ tracing: true }),
+        new Sentry.Integrations.Express({ app }),
+        ...Sentry.autoDiscoverNodePerformanceMonitoringIntegrations(),
+    ],
+    tracesSampleRate: process.env.SENTRY_TRACES_SAMPLE_RATE,
 });
 
 app.use(Sentry.Handlers.requestHandler());
@@ -41,7 +41,7 @@ if (process.env.NODE_ENV === "production") {
 
 // request에 담긴 정보를 json 형태로 파싱하기 위한 미들웨어들
 app.use(express.json());
-app.use(express.urlencoded({extended: true}));
+app.use(express.urlencoded({ extended: true }));
 app.use(cookieParser());
 
 if (process.env.NODE_ENV === "development") {
@@ -72,7 +72,7 @@ module.exports = functions
     })
     .region("asia-northeast3") // 서버가 돌아갈 region. asia-northeast3는 서울
     .https.onRequest(async (req, res) => {
-        
+
         // 들어오는 요청에 대한 로그를 콘솔에 찍기. 디버깅 때 유용하게 쓰일 예정.
         // 콘솔에 찍고 싶은 내용을 원하는 대로 추가하면 됨. (req.headers, req.query 등)
         console.log("\n\n", "[api]", `[${req.method.toUpperCase()}]`, req.originalUrl, req.body);

--- a/functions/api/routes/community/communityCategoryGET.js
+++ b/functions/api/routes/community/communityCategoryGET.js
@@ -1,0 +1,9 @@
+/**
+ *  @route GET /community/category
+ *  @desc 커뮤니티 카테고리 조회
+ *  @access Public
+ */
+
+module.exports = async (req, res) => {
+
+};

--- a/functions/api/routes/community/communityPostGET.js
+++ b/functions/api/routes/community/communityPostGET.js
@@ -1,0 +1,9 @@
+/**
+ *  @route GET /community/posts/:communityPostId
+ *  @desc 커뮤니티 게시글 상세 조회
+ *  @access Private
+ */
+
+module.exports = async (req, res) => {
+
+};

--- a/functions/api/routes/community/index.js
+++ b/functions/api/routes/community/index.js
@@ -1,0 +1,39 @@
+const express = require('express');
+const router = express.Router();
+const { checkUser } = require('../../../middlewares/auth');
+
+router.get('/category', require('./communityCategoryGET')
+    /**
+     * #swagger.summary = "커뮤니티 카테고리 전체 조회"
+     * #swagger.responses[200] = {
+           description: "커뮤니티 카테고리 조회 성공",
+           content: {
+               "application/json": {
+                   schema:{
+                       $ref: "#/components/schemas/responseCommunityCategorySchema"
+                   }
+               }           
+           }
+       }   
+   */
+);
+
+router.get('/posts/:communityPostId', checkUser, require('./communityPostGET')
+    /**
+     * #swagger.summary = "커뮤니티 게시글 상세 조회"
+     * #swagger.responses[200] = {
+            description: "커뮤니티 게시글 상세 조회 성공",
+            content: {
+                "application/json": {
+                    schema:{
+                        $ref: "#/components/schemas/responseCommunityPostsDetailSchema"
+                    }
+                }           
+            }
+        }   
+     * #swagger.responses[400]
+     * #swagger.responses[404] 
+    */
+);
+
+module.exports = router;

--- a/functions/api/routes/index.js
+++ b/functions/api/routes/index.js
@@ -2,7 +2,7 @@ const express = require('express');
 const router = express.Router();
 
 router.use(
-    '/content', require('./content') 
+    '/content', require('./content')
     /** 
      * #swagger.tags = ['content'] 
      * #swagger.responses[500] = {
@@ -15,7 +15,7 @@ router.use(
                }           
            }
        }   
-   */ 
+   */
 );
 router.use(
     '/category', require('./category')
@@ -96,12 +96,29 @@ router.use(
            }
        }   
    */
-    
+
 );
 router.use(
     '/health', require('./health')
     /** 
      * #swagger.tags = ['health'] 
+     * #swagger.responses[500] = {
+           description: "Internal Server Error",
+           content: {
+               "application/json": {
+                   schema:{
+                       $ref: "#/components/schemas/internalServerErrorSchema"
+                   }
+               }           
+           }
+       }   
+   */
+);
+
+router.use(
+    '/community', require('./community')
+    /** 
+     * #swagger.tags = ['community'] 
      * #swagger.responses[500] = {
            description: "Internal Server Error",
            content: {

--- a/functions/config/swagger.js
+++ b/functions/config/swagger.js
@@ -1,5 +1,5 @@
 const swaggerAutogen = require('swagger-autogen')({ openapi: '3.0.0' });
-const { commonErrorSchema, noticeSchema } = require('../constants/swagger/schemas');
+const { commonErrorSchema, noticeSchema, communitySchema } = require('../constants/swagger/schemas');
 const dotenv = require('dotenv');
 dotenv.config({ path: '.env.dev' });
 
@@ -32,6 +32,7 @@ const options = {
         schemas: {
             ...commonErrorSchema,
             ...noticeSchema,
+            ...communitySchema,
         }
     }
 };

--- a/functions/constants/swagger/schemas/communitySchema.js
+++ b/functions/constants/swagger/schemas/communitySchema.js
@@ -1,0 +1,34 @@
+const responseCommunityCategorySchema = {
+    $status: 200,
+    $success: true,
+    $message: "커뮤니티 카테고리 조회 성공",
+    $data: [
+        {
+            $id: 1,
+            $name: "UI/UX"
+        },
+    ]
+};
+
+const responseCommunityPostsDetailSchema = {
+    $status: 200,
+    $success: true,
+    $message: "커뮤니티 게시글 상세 조회 성공",
+    $data: {
+        $id: 1,
+        $nickname: "잡채",
+        $profileImage: "https://s3~",
+        $title: "제목",
+        $body: "본문",
+        $contentUrl: "https://naver.com",
+        $contentTitle: "콘텐츠 링크 제목",
+        $contentDescription: "콘텐츠 링크 설명",
+        $thumbnailUrl: "https://content-thumbnail-image-url",
+        $createdAt: "2024-02-01",
+    },
+}
+
+module.exports = {
+    responseCommunityCategorySchema,
+    responseCommunityPostsDetailSchema,
+};

--- a/functions/constants/swagger/schemas/index.js
+++ b/functions/constants/swagger/schemas/index.js
@@ -1,4 +1,5 @@
 module.exports = {
     commonErrorSchema: require('./commonErrorSchema'),
     noticeSchema: require('./noticeSchema'),
+    communitySchema: require('./communitySchema'),
 }


### PR DESCRIPTION
- close #329 
### 작업 내용
- 커뮤니티 카테고리 전체 조회 `GET /community/category`
- 커뮤니티 게시글 상세 조회 `GET /community/posts/:communityPostId` 
- swagger 명세 작성

### 명세서
<img width="1552" alt="image" src="https://github.com/TeamHavit/Havit-Server/assets/20807197/06081cb6-e99b-4bb5-bd93-7769db34b2fe">
<img width="1552" alt="image" src="https://github.com/TeamHavit/Havit-Server/assets/20807197/a5082286-2dbb-4ab1-99a2-0eb2b5e3db1f">
