### PR TITLE
[FIX] 커뮤니티 게시글 상세 조회 시 신고한 게시글 필터링 로직 추가

### DIFF
--- a/functions/api/routes/community/communityPostGET.js
+++ b/functions/api/routes/community/communityPostGET.js
@@ -29,7 +29,7 @@ module.exports = asyncWrapper(async (req, res) => {
   if (isReportedPost) {
     return res
       .status(statusCode.BAD_REQUEST)
-      .send(util.fail(statusCode.BAD_REQUEST, responseMessage.REPORTED_COMMUNITY_POST_ERROR));
+      .send(util.fail(statusCode.BAD_REQUEST, responseMessage.ALREADY_REPORTED_POST));
   }
 
   dayjs().format();

--- a/functions/api/routes/community/communityPostGET.js
+++ b/functions/api/routes/community/communityPostGET.js
@@ -15,20 +15,31 @@ const asyncWrapper = require('../../../lib/asyncWrapper');
  */
 
 module.exports = asyncWrapper(async (req, res) => {
+  const { userId } = req.user;
   const { communityPostId } = req.params;
-  if (!communityPostId) {
-    return res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, responseMessage.NULL_VALUE));
-  }
 
   const dbConnection = await db.connect(req);
   req.dbConnection = dbConnection;
+
+  const isReportedPost = await communityDB.getReportedPostByUser(
+    dbConnection,
+    userId,
+    communityPostId,
+  );
+  if (isReportedPost) {
+    return res
+      .status(statusCode.BAD_REQUEST)
+      .send(util.fail(statusCode.BAD_REQUEST, responseMessage.REPORTED_COMMUNITY_POST_ERROR));
+  }
 
   dayjs().format();
   dayjs.extend(customParseFormat);
 
   const communityPost = await communityDB.getCommunityPostDetail(dbConnection, communityPostId);
   if (!communityPost) {
-    return res.status(statusCode.NOT_FOUND).send(util.fail(statusCode.NOT_FOUND, responseMessage.NO_COMMUNITY_POST));
+    return res
+      .status(statusCode.NOT_FOUND)
+      .send(util.fail(statusCode.NOT_FOUND, responseMessage.NO_COMMUNITY_POST));
   }
 
   communityPost.createdAt = dayjs(`${communityPost.createdAt}`).format('YYYY. MM. DD');

--- a/functions/api/routes/community/index.js
+++ b/functions/api/routes/community/index.js
@@ -58,6 +58,7 @@ router.get(
 router.get(
   '/posts/:communityPostId',
   checkUser,
+  [...communityValidator.getCommunityPostValidator, validate],
   require('./communityPostGET'),
   /**
      * #swagger.summary = "커뮤니티 게시글 상세 조회"

--- a/functions/constants/responseMessage.js
+++ b/functions/constants/responseMessage.js
@@ -70,7 +70,7 @@ module.exports = {
   NO_COMMUNITY_CATEGORY: '존재하지 않는 커뮤니티 카테고리',
   NO_PAGE: '존재하지 않는 페이지',
   READ_COMMUNITY_CATEGORIES_SUCCESS: '커뮤니티 카테고리 조회 성공',
-  REPORTED_COMMUNITY_POST_ERROR: '신고한 게시글',
+  ALREADY_REPORTED_POST: '이미 신고한 게시글',
 
   // 서버 상태 체크
   HEALTH_CHECK_SUCCESS: '서버 상태 정상',

--- a/functions/constants/responseMessage.js
+++ b/functions/constants/responseMessage.js
@@ -70,6 +70,7 @@ module.exports = {
   NO_COMMUNITY_CATEGORY: '존재하지 않는 커뮤니티 카테고리',
   NO_PAGE: '존재하지 않는 페이지',
   READ_COMMUNITY_CATEGORIES_SUCCESS: '커뮤니티 카테고리 조회 성공',
+  REPORTED_COMMUNITY_POST_ERROR: '신고한 게시글',
 
   // 서버 상태 체크
   HEALTH_CHECK_SUCCESS: '서버 상태 정상',

--- a/functions/db/community.js
+++ b/functions/db/community.js
@@ -105,6 +105,19 @@ const getCommunityPostsCount = async (client, userId) => {
   return rows[0].count;
 };
 
+const getReportedPostByUser = async (client, userId, communityPostId) => {
+  const { rows } = await client.query(
+    `
+    SELECT 1 
+    FROM community_post_report_user cpru
+    WHERE cpru.report_user_id = $1 AND cpru.community_post_id = $2
+    `,
+    [userId, communityPostId],
+  );
+
+  return rows[0];
+};
+
 module.exports = {
   getCommunityPostDetail,
   getCommunityPosts,
@@ -113,4 +126,5 @@ module.exports = {
   verifyExistCategories,
   getCommunityCategories,
   getCommunityPostsCount,
+  getReportedPostByUser,
 };

--- a/functions/middlewares/validator/communityValidator.js
+++ b/functions/middlewares/validator/communityValidator.js
@@ -1,4 +1,4 @@
-const { body, query } = require('express-validator');
+const { body, query, param } = require('express-validator');
 
 const createCommunityPostValidator = [
   body('communityCategoryIds')
@@ -16,7 +16,15 @@ const getCommunityPostsValidator = [
   query('limit').notEmpty().isInt({ min: 1 }).withMessage('Invalid limit field'),
 ];
 
+const getCommunityPostValidator = [
+  param('communityPostId')
+    .notEmpty()
+    .isInt({ min: 1 })
+    .withMessage('Invalid communityPostId field'),
+];
+
 module.exports = {
   createCommunityPostValidator,
   getCommunityPostsValidator,
+  getCommunityPostValidator,
 };


### PR DESCRIPTION
- closes #350 

### 작업 내역
- 상세 조회 하기 전에 먼저 `community_post_report_user` 에 요청자의 `userId` 와 요청 `communityPostId` 가 매칭되는 데이터가 있는지 검사
- 신고한 이력이 있을 경우 400 에러 반환
- 추가로 params validation 시 validator 사용하도록 변경했습니다.

<img width="659" alt="image" src="https://github.com/TeamHavit/Havit-Server/assets/20807197/a2c10d36-875f-4112-b492-e2815125c03a">
