### PR TITLE
[FIX] 커뮤니티 게시물 조회 response에 작성자 본인여부 bool 타입 추가

### DIFF
--- a/functions/api/routes/community/communityPostGET.js
+++ b/functions/api/routes/community/communityPostGET.js
@@ -35,7 +35,11 @@ module.exports = asyncWrapper(async (req, res) => {
   dayjs().format();
   dayjs.extend(customParseFormat);
 
-  const communityPost = await communityDB.getCommunityPostDetail(dbConnection, communityPostId);
+  const communityPost = await communityDB.getCommunityPostDetail(
+    dbConnection,
+    communityPostId,
+    userId,
+  );
   if (!communityPost) {
     return res
       .status(statusCode.NOT_FOUND)

--- a/functions/constants/swagger/schemas/communitySchema.js
+++ b/functions/constants/swagger/schemas/communitySchema.js
@@ -25,6 +25,7 @@ const responseCommunityPostsDetailSchema = {
     contentDescription: '콘텐츠 링크 설명',
     $thumbnailUrl: 'https://content-thumbnail-image-url',
     $createdAt: '2024. 02. 01',
+    $isAuthor: true,
   },
 };
 
@@ -45,6 +46,7 @@ const responseCommunityPostsSchema = {
         contentDescription: '콘텐츠 링크 설명1',
         $thumbnailUrl: 'https://content-thumbnail-image-url1',
         $createdAt: '2024. 02. 01',
+        $isAuthor: true,
       },
       {
         $id: 2,
@@ -57,6 +59,7 @@ const responseCommunityPostsSchema = {
         contentDescription: '콘텐츠 링크 설명2',
         $thumbnailUrl: 'https://content-thumbnail-image-url2',
         $createdAt: '2024. 02. 02',
+        $isAuthor: false,
       },
       {
         $id: 3,
@@ -69,6 +72,7 @@ const responseCommunityPostsSchema = {
         contentDescription: '콘텐츠 링크 설명3',
         $thumbnailUrl: 'https://content-thumbnail-image-url3',
         $createdAt: '2024. 02. 03',
+        $isAuthor: false,
       },
     ],
     $currentPage: 1,

--- a/functions/db/community.js
+++ b/functions/db/community.js
@@ -1,14 +1,15 @@
 const convertSnakeToCamel = require('../lib/convertSnakeToCamel');
 
-const getCommunityPostDetail = async (client, communityPostId) => {
+const getCommunityPostDetail = async (client, communityPostId, userId) => {
   const { rows } = await client.query(
     `
-    SELECT cp.id, u.nickname, cp.title, cp.body, cp.content_url, cp.content_title, cp.content_description, cp.thumbnail_url, cp.created_at
+    SELECT cp.id, u.nickname, cp.title, cp.body, cp.content_url, cp.content_title, cp.content_description, cp.thumbnail_url, cp.created_at,
+      CASE WHEN cp.user_id = $2 THEN TRUE ELSE FALSE END as is_author
     FROM community_post cp
     JOIN "user" u on cp.user_id = u.id
     WHERE cp.id = $1 AND cp.is_deleted = FALSE
     `,
-    [communityPostId],
+    [communityPostId, userId],
   );
 
   return convertSnakeToCamel.keysToCamel(rows[0]);
@@ -17,7 +18,8 @@ const getCommunityPostDetail = async (client, communityPostId) => {
 const getCommunityPosts = async (client, userId, limit, offset) => {
   const { rows } = await client.query(
     `
-    SELECT cp.id, u.nickname, cp.title, cp.body, cp.content_url, cp.content_title, cp.content_description, cp.thumbnail_url, cp.created_at
+    SELECT cp.id, u.nickname, cp.title, cp.body, cp.content_url, cp.content_title, cp.content_description, cp.thumbnail_url, cp.created_at,
+      CASE WHEN cp.user_id = $1 THEN TRUE ELSE FALSE END as is_author
     FROM community_post cp
     JOIN "user" u ON cp.user_id = u.id
     LEFT JOIN community_post_report_user cpru ON cp.id = cpru.community_post_id AND cpru.report_user_id = $1


### PR DESCRIPTION
- closed #357 
### 작업 내용
- 프론트엔드에서 `신고 OR 삭제 바텀시트` 구분을 위해 커뮤니티 게시물 조회 response를 수정했습니다.
- 커뮤니티 게시물 상세/전체 조회 API의 response에 게시글 작성자 본인인지의 여부를 알 수 있는 bool 타입의 값 `isAuthor`을 추가했습니다.
### 구현 결과
- 커뮤니티 게시물 상세 조회 API
   <img width="545" alt="스크린샷 2024-06-16 오후 4 06 48" src="https://github.com/TeamHavit/Havit-Server/assets/65652094/c8415ee2-f7ef-487c-a255-3fda3b758cdc">

- 커뮤니티 게시물 전체 조회 API
   <img width="527" alt="스크린샷 2024-06-16 오후 4 14 08" src="https://github.com/TeamHavit/Havit-Server/assets/65652094/8d81deb4-6f15-434a-bb0a-87eb2df6bf07">


