### PR TITLE
[FIX] 커뮤니티 게시물 카테고리별 조회 response에 게시물 작성자 본인여부 bool 타입 추가

### DIFF
--- a/functions/db/community.js
+++ b/functions/db/community.js
@@ -157,7 +157,8 @@ const getCommunityCategoryPostsById = async (
 ) => {
   const { rows } = await client.query(
     `
-    SELECT cp.id, u.nickname, cp.title, cp.body, cp.content_url, cp.content_title, cp.content_description, cp.thumbnail_url, cp.created_at
+    SELECT cp.id, u.nickname, cp.title, cp.body, cp.content_url, cp.content_title, cp.content_description, cp.thumbnail_url, cp.created_at,
+      CASE WHEN cp.user_id = $1 THEN TRUE ELSE FALSE END as is_author
     FROM community_post cp
     JOIN "user" u ON cp.user_id = u.id
     JOIN community_category_post ccp ON cp.id = ccp.community_post_id


### PR DESCRIPTION
- closed #359 
### 작업 내용
#358 에서 커뮤니티 게시물 조회 response를 수정하면서, 카테고리별 게시물 조회 API의 response를 수정하지 않아 추가로 수정했습니다.
response에 게시글 작성자 본인인지의 여부를 알 수 있는 bool 타입의 값 isAuthor을 추가했습니다.
swagger는 이전 작업에서 수정했습니다!
### 구현 결과
#358 과 같습니다.
