### PR TITLE
[FEAT] 커뮤니티 게시글 신고 시 슬랙 알림 발송

### DIFF
--- a/functions/api/routes/community/communityReportPOST.js
+++ b/functions/api/routes/community/communityReportPOST.js
@@ -4,6 +4,8 @@ const responseMessage = require('../../../constants/responseMessage');
 const db = require('../../../db/db');
 const { communityDB } = require('../../../db');
 const asyncWrapper = require('../../../lib/asyncWrapper');
+const { getCommunityReportMessage } = require('../../../lib/slackMessage');
+const slackAPI = require('../../../middlewares/slackAPI');
 
 /**
  *  @route POST /community/reports
@@ -18,10 +20,27 @@ module.exports = asyncWrapper(async (req, res) => {
   const dbConnection = await db.connect(req);
   req.dbConnection = dbConnection;
 
-  const communityPostReport = await communityDB.reportCommunityPost(dbConnection, userId, communityPostId);
+  const communityPostReport = await communityDB.reportCommunityPost(
+    dbConnection,
+    userId,
+    communityPostId,
+  );
   if (!communityPostReport) {
-    return res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, responseMessage.NO_COMMUNITY_POST))
+    return res
+      .status(statusCode.BAD_REQUEST)
+      .send(util.fail(statusCode.BAD_REQUEST, responseMessage.NO_COMMUNITY_POST));
   }
-  
-  res.status(statusCode.CREATED).send(util.success(statusCode.CREATED, responseMessage.REPORT_COMMUNITY_POST_SUCCESS))
+
+  const slackReportMessage = getCommunityReportMessage(
+    userId,
+    communityPostId,
+    communityPostReport.title,
+    communityPostReport.postUserId,
+  );
+
+  slackAPI.sendMessageToSlack(slackReportMessage, slackAPI.WEB_HOOK_ERROR_MONITORING, true);
+
+  res
+    .status(statusCode.CREATED)
+    .send(util.success(statusCode.CREATED, responseMessage.REPORT_COMMUNITY_POST_SUCCESS));
 });

--- a/functions/db/community.js
+++ b/functions/db/community.js
@@ -183,6 +183,9 @@ const reportCommunityPost = async (client, userId, communityPostId) => {
     [communityPostId],
   );
   if (!existingCommunityPosts[0]) return existingCommunityPosts[0];
+
+  const { title, user_id: postUserId } = existingCommunityPosts[0];
+
   const { rows: communityPostReports } = await client.query(
     `
     INSERT INTO community_post_report_user
@@ -193,7 +196,11 @@ const reportCommunityPost = async (client, userId, communityPostId) => {
     `,
     [userId, communityPostId],
   );
-  return convertSnakeToCamel.keysToCamel(communityPostReports[0]);
+  return {
+    ...convertSnakeToCamel.keysToCamel(communityPostReports[0]),
+    title,
+    postUserId,
+  };
 };
 
 const getCommunityPostById = async (client, communityPostId) => {

--- a/functions/lib/slackMessage.js
+++ b/functions/lib/slackMessage.js
@@ -1,0 +1,28 @@
+const getCommunityReportMessage = (userId, postId, title, postUserId) => `
+    {
+        "blocks": [
+            {
+                "type": "header",
+                "text": {
+                    "type": "plain_text",
+                    "text": "🚨 게시글 신고 알림 🚨",
+                    "emoji": true
+                }
+            },
+            {
+                "type": "divider"
+            },
+            {
+                "type": "context",
+                "elements": [
+                    {
+                        "type": "mrkdwn",
+                        "text": "*신고 유저 ID*: ${userId} \n *신고 게시글 ID: ${postId} * \n *게시글 제목:* ${title} \n *게시글 작성자 ID*: ${postUserId}"
+                    }
+                ]
+            }
+        ]
+    }
+`;
+
+module.exports = { getCommunityReportMessage };

--- a/functions/middlewares/slackAPI.js
+++ b/functions/middlewares/slackAPI.js
@@ -5,25 +5,31 @@ const axios = require('axios');
 // endpoint 자체는 깃허브에 올라가면 안 되기 때문!
 const WEB_HOOK_ERROR_MONITORING = process.env.WEB_HOOK_ERROR_MONITORING;
 
-const sendMessageToSlack = (message, apiEndPoint = WEB_HOOK_ERROR_MONITORING) => {
-    // 슬랙 Webhook을 이용해 슬랙에 메시지를 보내는 코드
-    try {
-        axios
-            .post(apiEndPoint, { text: message })
-            .then((response) => { })
-            .catch((e) => {
-                throw e;
-            });
-    } catch (e) {
-        console.error(e);
-        // 슬랙 Webhook 자체에서 에러가 났을 경우,
-        // Firebase 콘솔에 에러를 찍는 코드
-        functions.logger.error('[slackAPI 에러]', { error: e });
-    }
+const sendMessageToSlack = (
+  message,
+  apiEndPoint = WEB_HOOK_ERROR_MONITORING,
+  isBlockMessage = false,
+) => {
+  // 슬랙 Webhook을 이용해 슬랙에 메시지를 보내는 코드
+  const body = isBlockMessage ? message : { text: message };
+
+  try {
+    axios
+      .post(apiEndPoint, body)
+      .then((response) => {})
+      .catch((e) => {
+        throw e;
+      });
+  } catch (e) {
+    console.error(e);
+    // 슬랙 Webhook 자체에서 에러가 났을 경우,
+    // Firebase 콘솔에 에러를 찍는 코드
+    functions.logger.error('[slackAPI 에러]', { error: e });
+  }
 };
 
 // 이 파일에서 정의한 변수 / 함수를 export 해서, 다른 곳에서 사용할 수 있게 해주는 코드
 module.exports = {
-    sendMessageToSlack,
-    WEB_HOOK_ERROR_MONITORING,
+  sendMessageToSlack,
+  WEB_HOOK_ERROR_MONITORING,
 };


### PR DESCRIPTION
- closed #352 
### 작업 내용
- 커뮤니티 게시글 신고 시 슬랙 알림 메시지를 발송하는 로직 추가
- 게시글 정보를 담기 위해 커뮤니티 신고 쿼리에서 title, 작성자 id 추가 반환
- 신고를 위한 슬랙 메시지 템플릿 작성
- 기존 에러 메시지는 text로 전달하고, 신고 알림은 block 메시지라 메시지 타입에 따라 slack webhook body를 바꾸는 로직을 추가했습니다.

메시지 바디에 더 추가하면 좋을 내용 있으면 말씀해주세요! 

관리 편의성을 높이려면 채널에 오는 알림 메시지에 버튼을 같이 두고 삭제 api를 연결하는 것도 좋을 것 같습니다 
(다만 함부로 삭제할 수 없도록 뭔가 앞단이 있어야할듯? 무튼 이건 더 생각해봅시다) 