### PR TITLE
[FIX] 스웨거에서  커뮤니티 게시글 삭제 api의 response body 삭제

### DIFF
--- a/functions/api/routes/community/communityPostDELETE.js
+++ b/functions/api/routes/community/communityPostDELETE.js
@@ -33,7 +33,5 @@ module.exports = asyncWrapper(async (req, res) => {
   await communityDB.deleteCommunityPostById(dbConnection, communityPostId);
   await communityDB.deleteCommunityCategoryPostByPostId(dbConnection, communityPostId);
 
-  res
-    .status(statusCode.NO_CONTENT)
-    .send(util.success(statusCode.NO_CONTENT, responseMessage.DELETE_COMMUNITY_POST_SUCCESS));
+  res.status(statusCode.NO_CONTENT).send();
 });

--- a/functions/api/routes/community/index.js
+++ b/functions/api/routes/community/index.js
@@ -196,13 +196,6 @@ router.delete(
         }
      * #swagger.responses[204] = {
             description: "커뮤니티 게시글 삭제 성공",
-            content: {
-                "application/json": {
-                    schema:{
-                        $ref: "#/components/schemas/responseDeleteCommunityPostSchema"
-                    }
-                }
-            } 
         }
      * #swagger.responses[400]
      * #swagger.responses[403]

--- a/functions/constants/swagger/schemas/communitySchema.js
+++ b/functions/constants/swagger/schemas/communitySchema.js
@@ -108,12 +108,6 @@ const requestCommunityReportSchema = {
   $communityPostId: 1,
 };
 
-const responseDeleteCommunityPostSchema = {
-  $status: 204,
-  $success: true,
-  $message: '커뮤니티 게시글 삭제 성공',
-};
-
 module.exports = {
   responseCommunityCategorySchema,
   responseCommunityPostsDetailSchema,
@@ -122,5 +116,4 @@ module.exports = {
   requestCreateCommunityPostSchema,
   responseCommunityReportSchema,
   requestCommunityReportSchema,
-  responseDeleteCommunityPostSchema,
 };


### PR DESCRIPTION
- closed #364 
### 작업 내용
스웨거에서 커뮤니티 게시글 삭제 api의 response body를 삭제했습니다.

게시글 삭제 api를 통해 게시글이 삭제했을 경우, 응답코드는 204이므로 response body가 없습니다.
하지만 스웨거 문서에는 response body에 값이 있는 것으로 작성되어 있어 이를 삭제합니다.

### 구현 결과
![image](https://github.com/user-attachments/assets/5ced181e-764b-49a5-9c53-1f6813a419eb)
